### PR TITLE
Fix meta-information for Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: libvirt
   author: 'Adfinis SyGroup AG'
   description: 'Install libvirt on a host'
   company: 'Adfinis SyGroup AG'
@@ -23,4 +24,5 @@ galaxy_info:
       versions:
         - 6
         - 7
-  galaxy_tags: []
+  galaxy_tags:
+    - libvirt


### PR DESCRIPTION
##### SUMMARY
meta/main.yml did not set the `role_name` attribute, which probably prevented it from being published on Ansible Galaxy. This pull request attempts to fix that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ayekat/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]
```