### PR TITLE
changed default libvirt packages

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,8 @@
 
 libvirt_packages:
   - qemu-kvm
-  - libvirt-bin
+  - libvirt-clients
+  - libvirt-daemon-system
   - bridge-utils
 
 libvirt_packages_lvm_backend: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed the Debian packages to install libvirt. The `libvirt-bin` package doesn't exist as such anymore and the content is splitted in the `libvirt-daemon-system` and `libvirt-clients` packages.

https://lists.debian.org/debian-user/2016/11/msg00518.html
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
All versions
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The changes have been tested with Debian 10 (libvirt is startet and enabled).
```